### PR TITLE
Fix logging not showing the mod name

### DIFF
--- a/Core.cs
+++ b/Core.cs
@@ -16,6 +16,7 @@ namespace ModelSwapLib
         public override void OnInitializeMelon()
         {
             BundleManager.GetInstance(); // Ensure BundleManager has been initialized
+            Melon<Core>.Logger.Msg("Initialized");
         }
         
         public override void OnDeinitializeMelon()
@@ -27,7 +28,7 @@ namespace ModelSwapLib
         {
             if (Keyboard.current != null && Keyboard.current.f5Key.wasPressedThisFrame)
             {
-                MelonLogger.Msg("Manual reload triggered.");
+                Melon<Core>.Logger.Msg("Manual reload triggered.");
                 reloadMessageStart = Time.time;
                 MelonEvents.OnGUI.Subscribe(DrawReloadText, 100);
             }

--- a/Swapper/Modules/IAssetModules/ColorDetailModule.cs
+++ b/Swapper/Modules/IAssetModules/ColorDetailModule.cs
@@ -21,7 +21,7 @@ public class ColorDetailModule : IAssetModule
         Texture2D colorDetailTexture = bundle.LoadAsset<Texture2D>(this.AssetPath);
         if (colorDetailTexture == null)
         {
-            MelonLogger.Error($"Failed to load Color Detail Texture2D: {this.AssetPath}");
+            Melon<Core>.Logger.Error($"Failed to load Color Detail Texture2D: {this.AssetPath}");
             return;
         }
         

--- a/Swapper/Modules/IAssetModules/ColorMainModule.cs
+++ b/Swapper/Modules/IAssetModules/ColorMainModule.cs
@@ -21,7 +21,7 @@ public class ColorMainModule : IAssetModule
         Texture2D colorMainTexture = bundle.LoadAsset<Texture2D>(this.AssetPath);
         if (colorMainTexture == null)
         {
-            MelonLogger.Error($"Failed to load Color Main Texture2D: {this.AssetPath}");
+            Melon<Core>.Logger.Error($"Failed to load Color Main Texture2D: {this.AssetPath}");
             return;
         }
         

--- a/Swapper/Modules/IAssetModules/ColorSecondaryModule.cs
+++ b/Swapper/Modules/IAssetModules/ColorSecondaryModule.cs
@@ -21,7 +21,7 @@ public class ColorSecondaryModule  : IAssetModule
         Texture2D colorSecondaryTexture = bundle.LoadAsset<Texture2D>(this.AssetPath);
         if (colorSecondaryTexture == null)
         {
-            MelonLogger.Error($"Failed to load Color Secondary Texture2D: {this.AssetPath}");
+            Melon<Core>.Logger.Error($"Failed to load Color Secondary Texture2D: {this.AssetPath}");
             return;
         }
         

--- a/Swapper/Modules/IAssetModules/EmmisionsModule.cs
+++ b/Swapper/Modules/IAssetModules/EmmisionsModule.cs
@@ -21,7 +21,7 @@ public class EmmisionsModule  : IAssetModule
         Texture2D emissionsTexture = bundle.LoadAsset<Texture2D>(this.AssetPath);
         if (emissionsTexture == null)
         {
-            MelonLogger.Error($"Failed to load Emissions Texture2D: {this.AssetPath}");
+            Melon<Core>.Logger.Error($"Failed to load Emissions Texture2D: {this.AssetPath}");
             return;
         }
         

--- a/Swapper/Modules/IAssetModules/MeshModule.cs
+++ b/Swapper/Modules/IAssetModules/MeshModule.cs
@@ -17,7 +17,7 @@ public class MeshModule : IAssetModule
         Mesh mesh = bundle.LoadAsset<Mesh>(this.AssetPath);
         if (mesh == null)
         {
-            MelonLogger.Error($"Failed to load Mesh: {this.AssetPath}");
+            Melon<Core>.Logger.Error($"Failed to load Mesh: {this.AssetPath}");
             return;
         }
         

--- a/Swapper/Modules/IAssetModules/MetallicModule.cs
+++ b/Swapper/Modules/IAssetModules/MetallicModule.cs
@@ -21,7 +21,7 @@ public class MetallicModule : IAssetModule
         Texture2D metallicTexture = bundle.LoadAsset<Texture2D>(this.AssetPath);
         if (metallicTexture == null)
         {
-            MelonLogger.Error($"Failed to load Metallic Texture2D: {this.AssetPath}");
+            Melon<Core>.Logger.Error($"Failed to load Metallic Texture2D: {this.AssetPath}");
             return;
         }
         

--- a/Swapper/Modules/IAssetModules/NormalsModule.cs
+++ b/Swapper/Modules/IAssetModules/NormalsModule.cs
@@ -21,7 +21,7 @@ public class NormalsModule : IAssetModule
         Texture2D normalTexture = bundle.LoadAsset<Texture2D>(this.AssetPath);
         if (normalTexture == null)
         {
-            MelonLogger.Error($"Failed to load Normals Texture2D: {this.AssetPath}");
+            Melon<Core>.Logger.Error($"Failed to load Normals Texture2D: {this.AssetPath}");
             return;
         }
         

--- a/Swapper/Modules/IAssetModules/Texture2DModule.cs
+++ b/Swapper/Modules/IAssetModules/Texture2DModule.cs
@@ -21,7 +21,7 @@ public class Texture2DModule : IAssetModule
         Texture2D mainTexture = bundle.LoadAsset<Texture2D>(this.AssetPath);
         if (mainTexture == null)
         {
-            MelonLogger.Error($"Failed to load Main Texture2D: {this.AssetPath}");
+            Melon<Core>.Logger.Error($"Failed to load Main Texture2D: {this.AssetPath}");
             return;
         }
         

--- a/Swapper/Swapper.cs
+++ b/Swapper/Swapper.cs
@@ -36,7 +36,7 @@ public class Swapper
                     var bundle = BundleManager.GetInstance().GetBundle(BundleName);
                     if (bundle == null)
                     {
-                        MelonLogger.Error($"Failed to load AssetBundle from Mod: {ModName}\nSwapper Name: {SwapperName}");
+                        Melon<Core>.Logger.Error($"Failed to load AssetBundle from Mod: {ModName}\nSwapper Name: {SwapperName}");
                         return;
                     }
                     assetModule.ApplyAll(objects, bundle);


### PR DESCRIPTION
As it turns out, using `MelonLogger.Msg` is not the right way to do it.

The correct way is using the `LoggerInstance` as part of the MelonMod or `Melon<Core>.Logger` for a more global approach

This way the name of the mod will be added to the log message, otherwise it's a toss up whether it's shown or not
<img width="531" height="157" alt="Jump_Space_gEgOFnBCvE" src="https://github.com/user-attachments/assets/fb2226d5-fa4c-4057-80ed-284bc313cb59" />

## Additional changes
- Added a log message after initialization